### PR TITLE
Add version display in popup

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <div class="container">
-    <h1>DoganayLab API Translate App</h1>
+    <h1>DoganayLab API Translate App <span id="version"></span></h1>
     
     <div class="form-group">
       <label for="apiKey">Gemini API Key:</label>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
+  // Display extension version
+  document.getElementById('version').textContent = 'v' + chrome.runtime.getManifest().version;
   const apiKeyInput = document.getElementById('apiKey');
   const saveApiKeyButton = document.getElementById('saveApiKey');
   const apiKeySavedMessage = document.getElementById('apiKeySaved');


### PR DESCRIPTION
Display current extension version from manifest in the popup window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The extension popup now displays the current version number directly in its header. This enhancement lets users immediately view the version information upon loading, promoting transparency and an improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->